### PR TITLE
Solve crash issue on releasing camera

### DIFF
--- a/h264MediaCodecStreamer/src/com/example/h264codecstreamer/MainStreamerActivity.java
+++ b/h264MediaCodecStreamer/src/com/example/h264codecstreamer/MainStreamerActivity.java
@@ -102,6 +102,7 @@ public class MainStreamerActivity extends Activity implements
 						// TODO Auto-generated method stub
 						if (camera != null && previewing) {
 							camera.stopPreview();
+							camera.setPreviewCallback(null);
 							camera.release();
 							camera = null;
 							avcEncode.close();


### PR DESCRIPTION
Crashing on pressing stop camera preview:

``` java
09-15 10:58:34.577: W/dalvikvm(11327): threadid=1: thread exiting with uncaught exception (group=0x41ddaba8)
09-15 10:58:34.577: E/AndroidRuntime(11327): FATAL EXCEPTION: main
09-15 10:58:34.577: E/AndroidRuntime(11327): Process: com.example.h264codecstreamer, PID: 11327
09-15 10:58:34.577: E/AndroidRuntime(11327): java.lang.RuntimeException: Method called after release()
09-15 10:58:34.577: E/AndroidRuntime(11327):    at android.hardware.Camera.setHasPreviewCallback(Native Method)
09-15 10:58:34.577: E/AndroidRuntime(11327):    at android.hardware.Camera.access$600(Camera.java:138)
09-15 10:58:34.577: E/AndroidRuntime(11327):    at android.hardware.Camera$EventHandler.handleMessage(Camera.java:934)
09-15 10:58:34.577: E/AndroidRuntime(11327):    at android.os.Handler.dispatchMessage(Handler.java:102)
09-15 10:58:34.577: E/AndroidRuntime(11327):    at android.os.Looper.loop(Looper.java:136)
09-15 10:58:34.577: E/AndroidRuntime(11327):    at android.app.ActivityThread.main(ActivityThread.java:5001)
09-15 10:58:34.577: E/AndroidRuntime(11327):    at java.lang.reflect.Method.invokeNative(Native Method)
09-15 10:58:34.577: E/AndroidRuntime(11327):    at java.lang.reflect.Method.invoke(Method.java:515)
09-15 10:58:34.577: E/AndroidRuntime(11327):    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:785)
09-15 10:58:34.577: E/AndroidRuntime(11327):    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:601)
09-15 10:58:34.577: E/AndroidRuntime(11327):    at dalvik.system.NativeStart.main(Native Method)
```

We have to unset preview callback before `camera.release()`, after `camera.stopPreview()`:

``` java
camera.setPreviewCallback(null)
```

Otherwise it might get called after camera has been released.
